### PR TITLE
Fixed NN Testimonials WP_ERROR Bug

### DIFF
--- a/lib/class-nn-testimonial-widget.php
+++ b/lib/class-nn-testimonial-widget.php
@@ -59,7 +59,7 @@ if (!class_exists('NN_Testimonial_Widget')):
                 $html = "This widget requires the NN_API class";
             }
 
-            if (!empty($nn_data)) {
+            if (!empty($nn_data) && !is_wp_error($nn_data)) {
 
                 $fiveStarReviews = array_values(array_filter($nn_data['reviews'], [$this, 'findReviews']));
 


### PR DESCRIPTION
If $nn_data was WP_ERROR it was breaking websites.  Fix was the same as the NN badge fix of the same nature.